### PR TITLE
横スクロールバーの表示を防ぐため 100vw の代わりに 100% を使う

### DIFF
--- a/main.css
+++ b/main.css
@@ -1,5 +1,5 @@
 body{
-    width: 100vw;
+    width: 100%;
     height: 100vh;
     margin: 0;
     color: rgba(85,85,85,1);
@@ -56,7 +56,7 @@ ul{
 }
 */
 .top-logo{
-    width: 100vw;
+    width: 100%;
     height: 100vh;
     display: flex;
     justify-content: center;
@@ -271,7 +271,7 @@ table td{
 }
 
 footer{
-    width: 100vw;
+    width: 100%;
     height: 100px;
     text-align: center;
 }


### PR DESCRIPTION
`100vw` は縦スクロールバーを含めた幅であるため，縦スクロールバーが表示される限り横スクロールバーも表示されてしまいます．
代わりに `100%` を用いることで，これを防ぐことができます．

|Before|After|
|---|---|
|![image](https://user-images.githubusercontent.com/12772118/93666899-cc80a500-fabc-11ea-948d-bd20f2e666eb.png)|![image](https://user-images.githubusercontent.com/12772118/93666895-c12d7980-fabc-11ea-8667-77846d3b9ed8.png)|
